### PR TITLE
Fixed issue in ImageLineHelper.cs

### DIFF
--- a/Hjg.Pngcs/ImageLineHelper.cs
+++ b/Hjg.Pngcs/ImageLineHelper.cs
@@ -71,14 +71,19 @@ namespace Hjg.Pngcs
             return ((a) << 24) | ((r) << 16) | ((g) << 8) | (b);
         }
 
-        public static int ToARGB8(int[] buff, int offset, bool alpha)
-        {
-            return alpha ? ToARGB8(buff[offset++], buff[offset++], buff[offset++], buff[offset]) : ToARGB8(buff[offset++], buff[offset++], buff[offset]);
-        }
+         public static int ToARGB8(int[] buff, int offset, bool alpha)
+         {
+            return alpha
+                ? ToARGB8(buff[offset++], buff[offset++], buff[offset++], buff[offset])
+                : ToARGB8(buff[offset++], buff[offset++], buff[offset]);
+         }
 
-        public static int ToARGB8(byte[] buff, int offset, bool alpha) {
-            return alpha ? ToARGB8(buff[offset++], buff[offset++], buff[offset++], buff[offset]) : ToARGB8(buff[offset++], buff[offset++], buff[offset]);
-        }
+         public static int ToARGB8(byte[] buff, int offset, bool alpha)
+         {
+            return alpha
+                ? ToARGB8(buff[offset++], buff[offset++], buff[offset++], buff[offset])
+                : ToARGB8(buff[offset++], buff[offset++], buff[offset]);
+         }
 
         public static void FromARGB8(int val, int[] buff, int offset, bool alpha)
         {


### PR DESCRIPTION
Fixed a bug in ImageLineHelper.cs to do with reading the Alpha channel of an image.
